### PR TITLE
new feature : ExpectAtLeast is the minimum number of registered services

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -38,6 +38,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, error) {
 	service := flags.String("service", "", "")
 	endpoint := flags.String("endpoint", "/", "")
 	expect := flags.Int("expect", 1, "")
+	expectAtLeast := flags.Int("expectAtLeast", 1, "")
 	retry := flags.Int("retry", 0, "")
 	timeout := flags.Int("timeout", 0, "")
 
@@ -46,10 +47,11 @@ func (cli *CLI) parseFlags(args []string) (*Config, error) {
 	}
 
 	config := &Config{
-		Consul:   *consul,
-		Service:  *service,
-		Endpoint: *endpoint,
-		Expect:   *expect,
+		Consul:        *consul,
+		Service:       *service,
+		Endpoint:      *endpoint,
+		Expect:        *expect,
+		ExpectAtLeast: *expectAtLeast,
 		Retry: gotry.Retry{
 			Max:     *retry,
 			Timeout: time.Duration(*timeout) * time.Millisecond,

--- a/cli_test.go
+++ b/cli_test.go
@@ -103,6 +103,21 @@ func TestParseFlags_expect(t *testing.T) {
 	}
 }
 
+func TestParseFlags_expectAtLeast(t *testing.T) {
+	cli := NewCLI()
+	config, err := cli.parseFlags([]string{
+		"-expectAtLeast", "3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := 4
+	if expected >= config.Expect {
+		t.Errorf("expected %d must higher than %d", expected, config.Expect)
+	}
+}
+
 func TestParseFlags_retry(t *testing.T) {
 	cli := NewCLI()
 	_, err := cli.parseFlags([]string{

--- a/cli_test.go
+++ b/cli_test.go
@@ -113,8 +113,8 @@ func TestParseFlags_expectAtLeast(t *testing.T) {
 	}
 
 	expected := 4
-	if expected >= config.Expect {
-		t.Errorf("expected %d must higher than %d", expected, config.Expect)
+	if expected < config.ExpectAtLeast {
+		t.Errorf("expected %d must higher than %d", expected, config.ExpectAtLeast)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// Expect is the number of registered service instances
 	Expect int
 
+	//ExpectAtLeast is the minimum number of registered service instances. Service instances can be more.
+	ExpectAtLeast int
+
 	//Retry is the number of retries to poke a service in case of failure
 	Retry gotry.Retry
 }

--- a/pocker.go
+++ b/pocker.go
@@ -49,6 +49,15 @@ func (p *Pocker) Poke() (int, error) {
 			return err
 		}
 		numServices := len(services)
+		if p.Config.ExpectAtLeast != 1 {
+			if numServices >= p.Config.ExpectAtLeast {
+				return nil
+			} else {
+				err = fmt.Errorf("Expected at least %d services, but consul returned %d", p.Config.ExpectAtLeast, numServices)
+				log.Print(err)
+				return err
+			}
+		}
 		if numServices != p.Config.Expect {
 			err = fmt.Errorf("Expected %d services, but consul returned %d", p.Config.Expect, numServices)
 			log.Print(err)

--- a/pocker_test.go
+++ b/pocker_test.go
@@ -18,11 +18,12 @@ func TestPoke_healthyService(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "healthy-service",
-		Endpoint: "/health",
-		Expect:   1,
-		Retry:    gotry.Retry{},
+		Consul:        consul.HTTPAddr,
+		Service:       "healthy-service",
+		Endpoint:      "/health",
+		Expect:        1,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)
@@ -44,11 +45,12 @@ func TestPoke_unhealthyService(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "unhealthy-service",
-		Endpoint: "/health",
-		Expect:   2,
-		Retry:    gotry.Retry{},
+		Consul:        consul.HTTPAddr,
+		Service:       "unhealthy-service",
+		Endpoint:      "/health",
+		Expect:        2,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)
@@ -70,11 +72,12 @@ func TestPoke_noSuchService(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "unknown-service",
-		Endpoint: "/health",
-		Expect:   1,
-		Retry:    gotry.Retry{},
+		Consul:        consul.HTTPAddr,
+		Service:       "unknown-service",
+		Endpoint:      "/health",
+		Expect:        1,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)
@@ -96,11 +99,12 @@ func TestPoke_emptyService(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "",
-		Endpoint: "/health",
-		Expect:   1,
-		Retry:    gotry.Retry{},
+		Consul:        consul.HTTPAddr,
+		Service:       "",
+		Endpoint:      "/health",
+		Expect:        1,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)
@@ -122,11 +126,12 @@ func TestPoke_badExpect(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "healthy-service",
-		Endpoint: "/health",
-		Expect:   2,
-		Retry:    gotry.Retry{},
+		Consul:        consul.HTTPAddr,
+		Service:       "healthy-service",
+		Endpoint:      "/health",
+		Expect:        2,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)
@@ -148,11 +153,12 @@ func TestPoke_retryServiceCheck(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "another-unhealthy-service",
-		Endpoint: "/health",
-		Expect:   1,
-		Retry:    gotry.Retry{Max: 1, Timeout: 2 * time.Second},
+		Consul:        consul.HTTPAddr,
+		Service:       "another-unhealthy-service",
+		Endpoint:      "/health",
+		Expect:        1,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{Max: 1, Timeout: 2 * time.Second},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)
@@ -181,11 +187,12 @@ func TestPoke_restryExpect(t *testing.T) {
 	defer consul.Stop()
 
 	conf := &Config{
-		Consul:   consul.HTTPAddr,
-		Service:  "unhealthy-service",
-		Endpoint: "/health",
-		Expect:   3,
-		Retry:    gotry.Retry{Max: 1, Timeout: 2 * time.Second},
+		Consul:        consul.HTTPAddr,
+		Service:       "unhealthy-service",
+		Endpoint:      "/health",
+		Expect:        3,
+		ExpectAtLeast: 1,
+		Retry:         gotry.Retry{Max: 1, Timeout: 2 * time.Second},
 	}
 	client := testHTTPClient(t, conf)
 	setupConsul(t, consul)


### PR DESCRIPTION
example logs of this feature...

ubuntu@ubuntu-01:~$ ./pocker -consul 10.15.25.35:8500 -expectAtLeast 4 -service example-app -endpoint / -retry 3 -timeout 5000
2016/08/05 09:33:00 Running: [-consul 10.15.25.35:8500 -expectAtLeast 4 -service example-app -endpoint / -retry 3 -timeout 5000]
2016/08/05 09:33:00 Retrieving service example-app from consul (10.15.25.35:8500)
2016/08/05 09:33:00 Expected at least 4 services, but consul returned 3

ubuntu@ubuntu-01:~$ ./pocker -consul 10.15.25.35:8500 -expectAtLeast 2 -service example-app -endpoint / -retry 3 -timeout 5000
2016/08/05 09:41:17 Running: [-consul 10.15.25.35:8500 -expectAtLeast 2 -service example-app -endpoint / -retry 3 -timeout 5000]
2016/08/05 09:41:17 Retrieving service example-app from consul (10.15.25.35:8500)
2016/08/05 09:41:17 Poking http://10.15.25.36:32785/
2016/08/05 09:41:17 Poking http://10.15.25.37:32777/
2016/08/05 09:41:17 Poking http://10.15.25.38:32775/
